### PR TITLE
Fixed a mistake with the old Wizz Air livery

### DIFF
--- a/Models/Liveries/A320/IAE/WZZ-old.xml
+++ b/Models/Liveries/A320/IAE/WZZ-old.xml
@@ -14,5 +14,5 @@
 		<EIS2 type="bool">1</EIS2>
 	</options>
 	
-	<sharklet type="bool">0</sharklet>
+	<sharklet type="bool">1</sharklet>
 </PropertyList>


### PR DESCRIPTION
Sharklets were disabled in the XML file when they needed to be enabled